### PR TITLE
fix: Can not update plugins due to request timeout

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -429,7 +429,7 @@ class Updater
             return $reply; // Must be a local file.
         }
         
-        $response = wp_remote_get($package);
+        $response = wp_remote_get($package, [ 'method' => 'HEAD' ]);
     
         if (is_wp_error($response) || wp_remote_retrieve_response_code($response) != 200) {
     


### PR DESCRIPTION
The user can not update the plugin from the plugin list or dashboard update page due to duplicate downloading of the file in the Appsero updater.

- this will fix https://github.com/getdokan/dokan-pro/issues/3729