### PR TITLE
fix: WPML plugin upgrade conflicts with appsero url validation.

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -428,8 +428,8 @@ class Updater
         if ( ! preg_match( '!^(http|https|ftp)://!i', $package ) && file_exists( $package ) ) {
             return $reply; // Must be a local file.
         }
-        
-        $response = wp_remote_get($package, [ 'method' => 'HEAD' ]);
+
+	    $response = wp_remote_get($package, ['method' => 'HEAD', 'redirection' => 5, 'timeout' => 20]);
     
         if (is_wp_error($response) || wp_remote_retrieve_response_code($response) != 200) {
     

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -429,7 +429,7 @@ class Updater
             return $reply; // Must be a local file.
         }
 
-	    $response = wp_remote_get($package, ['method' => 'HEAD', 'redirection' => 5, 'timeout' => 20]);
+	$response = wp_remote_get($package, ['method' => 'HEAD', 'redirection' => 5, 'timeout' => 20]);
     
         if (is_wp_error($response) || wp_remote_retrieve_response_code($response) != 200) {
     

--- a/src/Updater.php
+++ b/src/Updater.php
@@ -429,8 +429,8 @@ class Updater
             return $reply; // Must be a local file.
         }
 
-	$response = wp_remote_get($package, ['method' => 'HEAD', 'redirection' => 5, 'timeout' => 20]);
-    
+	$response = wp_remote_get($package, ['method' => 'HEAD', 'redirection' => 5]);
+
         if (is_wp_error($response) || wp_remote_retrieve_response_code($response) != 200) {
     
             $error_message = is_wp_error($response) 


### PR DESCRIPTION
### Fix: Conflict Between Appsero updater url validation and WPML Plugins During WPML Updates.

#### Summary
Nico from the WPML Compatibility team reached out to report an issue with Dokan Pro interfering with WPML plugin updates. One of our clients reported the issue on the official WPML forum. The topic can be accessed here: [[WPML and Dokan Pro Conflict](https://wpml.org/forums/topic/split-wpml-and-dokan-pro-conflict/)]

#### Problem Description
When the Dokan Pro plugin is enabled, the WPML plugin cannot be updated from the **Commercial** tab. The `\Plugin_Upgrader::upgrade` method returns an error message `invalid_update_url`.

#### Debug Findings by WPML Team
The issue arises because Dokan Pro hooks into the `upgrader_pre_download` filter and modifies it in the `\WeDevs\DokanPro\Dependencies\Appsero\Updater::validate_plugin_update_url` function. The relevant code is as follows:

```php
public function validate_plugin_update_url($reply, $package) {
    // Local file or remote?
    if ( ! preg_match( '!^(http|https|ftp)://!i', $package ) && file_exists( $package ) ) {
        return $reply; // Must be a local file.
    }
    
    $response = wp_remote_get($package, [ 'method' => 'HEAD' ]);

    if (is_wp_error($response) || wp_remote_retrieve_response_code($response) != 200) {
        $error_message = is_wp_error($response) 
            ? $response->get_error_message() 
            : wp_remote_retrieve_body($response);

        if (empty($error_message)) {
            $error_message = wp_remote_retrieve_response_message($response);
        }

        return new \WP_Error('invalid_update_url', $error_message);
    }

    return $reply;
}
```

**Issue Details:**
- The `wp_remote_get` call used in the code returns a `302` response code, which is valid and does not imply the resource is unavailable.
- However, the code interprets this as an error and blocks the update process for WPML plugins.

#### Workarounds Provided by WPML Team
1. Manually update the WPML plugins.
2. Comment out the filter in `wp-content/plugins/dokan-pro/dependencies/Appsero/Updater.php` line 45:
   ```php
   // add_filter('upgrader_pre_download', [$this , 'validate_plugin_update_url'], 10, 2);
   ```

#### Steps to Reproduce
1. Install and activate the Dokan Pro plugin.
2. Navigate to the **Commercial** tab of the WPML plugin.
3. Attempt to update WPML plugins.
4. Observe the `invalid_update_url` error.

#### Expected Behavior
WPML plugins should update successfully from the **Commercial** tab without interference from Dokan Pro.

#### Actual Behavior
An error is thrown during the update process, and WPML plugins cannot be updated when Dokan Pro is active.

#### Suggested Fix
- Modify the `validate_plugin_update_url` function to correctly handle `302` response codes.
- Update the logic in `wp_remote_get` to avoid blocking valid response codes like `302`.

#### References
- [[WPML Forum Topic](https://wpml.org/forums/topic/split-wpml-and-dokan-pro-conflict/)]

