### PR TITLE
fix: Plugin update message do not display after dependent plugin version update

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -68,75 +68,45 @@ class Updater
     }
 
     /**
-     * Set up WordPress filter hooks to get plugin updates
+     * Initialize the admin hooks
      *
      * @return void
      */
-    public function run_plugin_hooks()
-    {
-        add_action('admin_init', [$this, 'check_plugin_update']);
-    }
-
-    /**
-     * Set up WordPress filter hooks to get theme updates
-     *
-     * @return void
-     */
-    public function run_theme_hooks()
-    {
-        add_filter('pre_set_site_transient_update_themes', [$this, 'check_theme_update']);
+    public function admin_init() {
+        add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'check_plugin_update' ] );
+        add_filter( 'plugins_api', [ $this, 'plugins_api_filter' ], 10, 3 );
+        $this->show_warning_notice();
     }
 
     /**
      * Check for plugin updates
      *
-     * @param object $transient_data
-     * @return object
+     * @param stdClass|bool $transient_data
+     * @return stdClass
      */
-    public function check_plugin_update($transient_data)
-    {
+    public function check_plugin_update( $transient_data ) {
         global $pagenow;
 
-        if (!is_object($transient_data)) {
+        if ( ! is_object( $transient_data ) ) {
             $transient_data = new stdClass();
         }
 
-        if ('plugins.php' === $pagenow && is_multisite()) {
-            return $transient_data;
-        }
-
-        if (!empty($transient_data->response) && !empty($transient_data->response[$this->client->basename])) {
+        if ( 'plugins.php' === $pagenow && is_multisite() ) {
             return $transient_data;
         }
 
         $version_info = $this->get_version_info();
 
-        if (false !== $version_info && is_object($version_info) && isset($version_info->new_version)) {
-            unset($version_info->sections);
+        if ( $version_info && is_object( $version_info ) && ! empty( $version_info->new_version ) ) {
+            unset( $version_info->sections );
 
-            // If new version available, set to response
-            if (version_compare($this->client->project_version, $version_info->new_version, '<')) {
-                $required_plugins = isset($version_info->required_plugins) && (is_array($version_info->required_plugins) || is_object($version_info->required_plugins))
-                ? $version_info->required_plugins
-                : [];
+            $key = version_compare( $this->client->project_version, $version_info->new_version, '<' )
+                ? 'response'
+                : 'no_update';
 
-                $warnings = $this->check_required_plugins($required_plugins);
-
-                if (!empty($warnings)) {
-                    $this->show_warning_notice($warnings);
-                } else {
-                    $transient_data->response[$this->client->basename] = $version_info;
-                    add_filter('pre_set_site_transient_update_plugins', function () use ($transient_data) {
-                        return $transient_data;
-                    });
-                    add_filter('plugins_api', [$this, 'plugins_api_filter'], 10, 3);
-                }
-            } else {
-                $transient_data->no_update[$this->client->basename] = $version_info;
-            }
-
+            $transient_data->{$key}[ $this->client->basename ] = $version_info;
             $transient_data->last_checked = time();
-            $transient_data->checked[$this->client->basename] = $this->client->project_version;
+            $transient_data->checked[ $this->client->basename ] = $this->client->project_version;
         }
 
         return $transient_data;
@@ -374,15 +344,50 @@ class Updater
     /**
      * Show warning notice for required plugins
      *
-     * @param array $warnings
      * @return void
      */
-    public function show_warning_notice($warnings)
-    {
-        add_action("after_plugin_row_{$this->client->basename}", function ($plugin_file, $plugin_data, $status) use ($warnings) {
-            $this->add_custom_plugin_row($plugin_file, $plugin_data, $status, $warnings);
-        }, 10, 3);
-    }
+    protected function show_warning_notice() {
+        $version_info = $this->get_version_info();
+        if ( false === $version_info || ! is_object( $version_info ) || ! isset( $version_info->new_version ) ) {
+            return;
+        }
+
+        unset( $version_info->sections );
+
+        // If no new version is available, return early
+        if ( version_compare( $this->client->project_version, $version_info->new_version, '>=' ) ) {
+            return;
+        }
+
+            $required_plugins = isset( $version_info->required_plugins ) && ( is_array( $version_info->required_plugins ) || is_object( $version_info->required_plugins ) )
+                ? $version_info->required_plugins
+                : [];
+
+            $warnings = $this->check_required_plugins( $required_plugins );
+
+        if ( empty( $warnings ) ) {
+            return;
+        }
+
+        add_filter(
+            'site_transient_update_plugins',
+            function ( $transient ) {
+                if ( ! is_object( $transient ) || empty( $transient->response ) || empty( $transient->response[ $this->client->basename ] ) ) {
+                    return $transient;
+                }
+
+                unset( $transient->response[ $this->client->basename ] );
+
+                return $transient;
+            }
+        );
+
+        add_action(
+            "after_plugin_row_{$this->client->basename}", function ( $plugin_file, $plugin_data, $status ) use ( $warnings ) {
+                $this->add_custom_plugin_row( $plugin_file, $plugin_data, $status, $warnings );
+            }, 10, 3
+        );
+	}
 
     /**
      * Add custom plugin row with warnings


### PR DESCRIPTION
Currently, if a plugin has a version dependency and the dependency is updated, the update notice disappears.

fix: https://github.com/getdokan/dokan-pro/issues/4628